### PR TITLE
Escape HTML text and attributes

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ dependencies:
   - string-interpolate >= 0.3.2 && <0.4
   - file-embed >= 0.0.10 && <0.1
   - http-types >= 0.12 && <0.13
+  - html-entities >= 1.1.4.7 && <1.2
 
 library:
   source-dirs: src
@@ -58,5 +59,3 @@ tests:
     dependencies:
       - web-view
       - sydtest >= 0.15 && <0.16
-
-

--- a/src/Web/View/Render.hs
+++ b/src/Web/View/Render.hs
@@ -57,10 +57,7 @@ renderText' c u = intercalate "\n" content
   css = nonEmpty $ renderCSS $ (.css) $ runView c u
 
   styleElement :: Maybe Content
-  styleElement = case css of
-    Just css' -> Just $ Node $ Element "style" (Attributes [] [("type", "text/css")]) [Text $ intercalate "\n" $ toList css']
-    Nothing -> Nothing
-
+  styleElement = Node . Element "style" (Attributes [] [("type", "text/css")]) . pure . Text . intercalate "\n" . toList <$> css
 
 renderContent :: (Text -> Text) -> Content -> [Text]
 renderContent ind (Node t) = renderTag ind t

--- a/src/Web/View/Render.hs
+++ b/src/Web/View/Render.hs
@@ -12,11 +12,12 @@ import Data.List.NonEmpty (NonEmpty, nonEmpty)
 import Data.Map qualified as M
 import Data.Maybe (mapMaybe)
 import Data.String.Interpolate (i)
-import Data.Text (Text, intercalate, pack, replace, toLower, unlines, unwords)
+import Data.Text (Text, intercalate, pack, toLower, unlines, unwords)
 import Data.Text.Lazy qualified as L
 import Data.Text.Lazy.Encoding qualified as LE
 import Web.View.Types
 import Web.View.View (View, ViewState (..), runView, viewInsertContents)
+import HTMLEntities.Text qualified as HE
 import Prelude hiding (unlines, unwords)
 
 {- | Renders a 'View' as HTML with embedded CSS class definitions
@@ -63,7 +64,7 @@ renderText' c u = intercalate "\n" content
 
 renderContent :: (Text -> Text) -> Content -> [Text]
 renderContent ind (Node t) = renderTag ind t
-renderContent _ (Text t) = [escapeHTMLBody t]
+renderContent _ (Text t) = [HE.text t]
 renderContent _ (Raw t) = [t]
 
 
@@ -77,7 +78,7 @@ renderTag ind tag =
     -- single text node
     [Text t] ->
       -- SINGLE text node, just display it indented
-      [open <> htmlAtts (flatAttributes tag) <> ">" <> escapeHTMLBody t <> close]
+      [open <> htmlAtts (flatAttributes tag) <> ">" <> HE.text t <> close]
     _ ->
       mconcat
         [ [open <> htmlAtts (flatAttributes tag) <> ">"]
@@ -100,15 +101,7 @@ renderTag ind tag =
       <> unwords (map htmlAtt $ M.toList as)
    where
     htmlAtt (k, v) =
-      k <> "=" <> "'" <> escapeHTMLAttributes v <> "'"
-
-
-escapeHTMLBody :: Text -> Text
-escapeHTMLBody = replace "<" "&lt;" . replace ">" "&gt;" . replace "&" "&amp;"
-
-
-escapeHTMLAttributes :: Text -> Text
-escapeHTMLAttributes = replace "'" "&apos;" . replace "\"" "&quot;" . escapeHTMLBody
+      k <> "=" <> "'" <> HE.text v <> "'"
 
 
 renderCSS :: CSS -> [Text]

--- a/test/Test/RenderSpec.hs
+++ b/test/Test/RenderSpec.hs
@@ -21,6 +21,11 @@ spec = do
     it "should escape properly" $ do
       let res = renderText $ el bold $ raw "<svg>&\"'</svg>"
       pureGoldenTextFile "test/resources/raw.txt" res
-    it "should skip css when no css attributes" $ do
-      let res = renderText $ el (addClass $ cls "empty") "hi"
+    it "should skip css class when no css attributes" $ do
+      let res = renderText $ do
+            el (addClass $ cls "empty") "i have no css"
+            el bold "i have some css"
+      pureGoldenTextFile "test/resources/nocssattrs.txt" res
+    it "should skip css element when no css rules" $ do
+      let res = renderText $ el (addClass $ cls "empty") "i have no css"
       pureGoldenTextFile "test/resources/nocss.txt" res

--- a/test/Test/RenderSpec.hs
+++ b/test/Test/RenderSpec.hs
@@ -2,6 +2,7 @@ module Test.RenderSpec (spec) where
 
 import Test.Syd
 import Web.View
+import Web.View.Style
 
 
 spec :: Spec
@@ -10,3 +11,16 @@ spec = do
     it "should match expected output" $ do
       let res = renderText $ el bold "hi"
       pureGoldenTextFile "test/resources/basic.txt" res
+    it "should escape properly" $ do
+      let res = renderText $ do
+            el (att "title" "I have some apos' and quotes \" and I'm a <<great>> attribute!!!") "I am <malicious> &apos;user"
+            el (att "title" "I have some apos' and quotes \" and I'm a <<great>> attribute!!!") $ do
+              text "I am <malicious> &apos;user"
+              text "I am another <malicious> &apos;user"
+      pureGoldenTextFile "test/resources/escaping.txt" res
+    it "should escape properly" $ do
+      let res = renderText $ el bold $ raw "<svg>&\"'</svg>"
+      pureGoldenTextFile "test/resources/raw.txt" res
+    it "should skip css when no css attributes" $ do
+      let res = renderText $ el (addClass $ cls "empty") "hi"
+      pureGoldenTextFile "test/resources/nocss.txt" res

--- a/test/resources/escaping.txt
+++ b/test/resources/escaping.txt
@@ -1,6 +1,6 @@
-<div title='I have some apos&apos; and quotes &quot; and I&apos;m a &lt;&lt;great&gt;&gt; attribute!!!'>I am &lt;malicious&gt; &amp;apos;user</div>
+<div title='I have some apos&#39; and quotes &quot; and I&#39;m a &lt;&lt;great&gt;&gt; attribute!!!'>I am &lt;malicious&gt; &amp;apos;user</div>
 
-<div title='I have some apos&apos; and quotes &quot; and I&apos;m a &lt;&lt;great&gt;&gt; attribute!!!'>
+<div title='I have some apos&#39; and quotes &quot; and I&#39;m a &lt;&lt;great&gt;&gt; attribute!!!'>
   I am &lt;malicious&gt; &amp;apos;user
   I am another &lt;malicious&gt; &amp;apos;user
 </div>

--- a/test/resources/escaping.txt
+++ b/test/resources/escaping.txt
@@ -1,0 +1,6 @@
+<div title='I have some apos&apos; and quotes &quot; and I&apos;m a &lt;&lt;great&gt;&gt; attribute!!!'>I am &lt;malicious&gt; &amp;apos;user</div>
+
+<div title='I have some apos&apos; and quotes &quot; and I&apos;m a &lt;&lt;great&gt;&gt; attribute!!!'>
+  I am &lt;malicious&gt; &amp;apos;user
+  I am another &lt;malicious&gt; &amp;apos;user
+</div>

--- a/test/resources/nocss.txt
+++ b/test/resources/nocss.txt
@@ -1,0 +1,1 @@
+<div class='empty'>hi</div>

--- a/test/resources/nocss.txt
+++ b/test/resources/nocss.txt
@@ -1,1 +1,1 @@
-<div class='empty'>hi</div>
+<div class='empty'>i have no css</div>

--- a/test/resources/nocssattrs.txt
+++ b/test/resources/nocssattrs.txt
@@ -1,0 +1,5 @@
+<style type='text/css'>.bold { font-weight:bold }</style>
+
+<div class='empty'>i have no css</div>
+
+<div class='bold'>i have some css</div>

--- a/test/resources/raw.txt
+++ b/test/resources/raw.txt
@@ -1,0 +1,5 @@
+<style type='text/css'>.bold { font-weight:bold }</style>
+
+<div class='bold'>
+  <svg>&"'</svg>
+</div>

--- a/web-view.cabal
+++ b/web-view.cabal
@@ -56,6 +56,7 @@ library
     , containers >=0.6 && <1
     , effectful-core >=2.3 && <3
     , file-embed >=0.0.10 && <0.1
+    , html-entities >=1.1.4.7 && <1.2
     , http-types ==0.12.*
     , string-interpolate >=0.3.2 && <0.4
     , text >=1.2 && <3
@@ -87,6 +88,7 @@ test-suite tests
     , containers >=0.6 && <1
     , effectful-core >=2.3 && <3
     , file-embed >=0.0.10 && <0.1
+    , html-entities >=1.1.4.7 && <1.2
     , http-types ==0.12.*
     , string-interpolate >=0.3.2 && <0.4
     , sydtest ==0.15.*


### PR DESCRIPTION
Added golden tests for that. This is basically allowed code injection if user-provided data was rendered. I wonder if there are other cases it can break.

Also: 

* do not render empty class definitions
* do not render empty `<style>` tags
* formatted changed files with fourmolu