### PR TITLE
Add extClass convinience utiltiy for use-cases where CSS is provided externally

### DIFF
--- a/src/Web/View/Style.hs
+++ b/src/Web/View/Style.hs
@@ -364,11 +364,16 @@ addClass c attributes =
     , other = attributes.other
     }
 
-
 -- | Construct a class from a ClassName
 cls :: ClassName -> Class
 cls n = Class (selector n) []
 
+{- | Construct a mod from a ClassName with no CSS properties. Convenience for situations where external CSS classes need to be referenced.
+
+> el (extClass "btn" . extClass "btn-primary") "Click me!"
+-}
+extClass :: ClassName -> Mod
+extClass = addClass . cls
 
 -- | Add a property to a class
 prop :: (ToStyleValue val) => Name -> val -> Class -> Class


### PR DESCRIPTION
In response to the question in the other PR https://github.com/seanhess/web-view/pull/3#discussion_r1638420071 this helper makes it easier to add classes to HTML elements that are defined in 3rd party CSS. This is what I've been using in my project. Alternatively, `IsString` instance could be added to `Class` so `addClass` can be used directly. This however, can cause some confusion for people who will use web-view "as prescribed", as it'd be pretty easy to confuse `addClass $ cls "foo" & prop "foo" "bar"` with `addClass "foo" & prop "foo" "bar"`