### PR TITLE
feat: add nix flake and GitHub Actions workflow

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: "Build"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build packages
+        run: |
+          # Build all packages for the current system
+          nix build .#
+          nix build .#web-view
+
+      - name: Build devShells
+        run: |
+          # Build all devShells for the current system
+          nix develop .# -c true
+          nix develop .#web-view -c true
+          nix develop .#example -c true
+
+      - name: Check overlays
+        run: |
+          # Test that overlays exist
+          nix eval .#overlays

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ dist
 tags
 docs/old.md
 build
-
+.direnv

--- a/README.md
+++ b/README.md
@@ -71,6 +71,40 @@ el (width 100 . media (MinWidth 800) (width 400))
   "Big if window > 800"
 ```
 
+Local Development
+-----------------
+
+### Nix
+
+With nix installed, you can use `nix develop` to get a shell with all dependencies installed. 
+
+You can also try out the example project with:
+
+```
+cd example
+nix develop ../#example
+cabal run
+```
+
+You can import this flake's overlay to override your `haskellPackages` with the set we use to build `web-view` in this flake.
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    web-view.url = "github:seanhess/web-view"; # or "path:/path/to/cloned/web-view";
+  };
+
+  outputs = { self, nixpkgs, web-view }: {
+    # Apply the overlay to your packages
+    packages.x86_64-linux = import nixpkgs {
+      system = "x86_64-linux";
+      overlays = [ web-view.overlays.default ];
+    };
+  };
+}
+```
+
 
 Learn More
 ----------

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1731533336,
+        "narHash": "sha256-oRam5PS1vcrr5UPgALW0eo1m/5/pls27Z/pabHNy2Ms=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "f7653272fd234696ae94229839a99b73c9ab7de0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "main",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733686850,
+        "narHash": "sha256-NQEO/nZWWGTGlkBWtCs/1iF1yl2lmQ1oY/8YZrumn3I=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "dd51f52372a20a93c219e8216fe528a648ffcbf4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,100 @@
+{
+  description = "web-view";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nix-filter.url = "github:numtide/nix-filter/main";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = inputs@{ self, flake-utils, nix-filter, ... }: 
+    let
+      web-view-src = nix-filter.lib {
+        root = ./.;
+        include = [
+          (nix-filter.lib.inDirectory "src")
+          (nix-filter.lib.inDirectory "embed")
+          (nix-filter.lib.inDirectory "test")
+          ./README.md
+          ./CHANGELOG.md
+          ./LICENSE
+          ./web-view.cabal
+        ];
+      };
+
+      # build cabal2nix with a different package set as suggested by https://github.com/NixOS/nixpkgs/issues/83098#issuecomment-602132784
+      # Only with overlay, cabal2nix causes infinite recursion if one of it's dependencies is overridden
+      fixCabal2nix = self: super: {
+        cabal2nix-unwrapped = super.haskell.lib.justStaticExecutables
+          super.haskell.packages."ghc902".cabal2nix;
+      };
+      haskellOverlay = final: prev: {
+        haskellPackages = prev.haskellPackages.override {
+          overrides = hself: hsuper: {
+            web-view = hself.callCabal2nix "web-view" web-view-src { };
+            attoparsec-aeson = hself.callHackage "attoparsec-aeson" "2.2.0.0" {};
+            skeletest = hself.callHackage "skeletest" "0.1.0" {};
+            Diff = hself.callHackage "Diff" "0.5" {};
+            aeson = hself.callHackage "aeson" "2.2.2.0" {};
+          } // (final.lib.optionalAttrs (final.system == "x86_64-darwin" || final.system == "aarch64-darwin") {
+            crypton = final.haskell.lib.dontCheck hsuper.crypton;
+          });
+        };
+      };
+      overlay = final: prev:
+        let
+          fApplied = fixCabal2nix final prev;
+          prev' = prev // fApplied;
+        in
+        fApplied // haskellOverlay final prev';
+    in
+      flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [ overlay ];
+        };
+
+        example-src = nix-filter.lib {
+          root = ./example;
+          include = [
+            (nix-filter.lib.inDirectory "app")
+            ./example/example.cabal
+            ./example/cabal.project
+          ];
+        };
+
+        shellCommon = {
+          # don't use the modified package set to build dev tools
+          buildInputs = with inputs.nixpkgs.legacyPackages.${system}; [
+            haskellPackages.cabal-install
+            haskell-language-server
+            haskellPackages.fast-tags
+            haskellPackages.ghcid
+          ];
+          withHoogle = true;
+          doBenchmark = true;
+        };
+
+      in
+      {
+        overlays.default = overlay;
+        packages = {
+          default = pkgs.haskellPackages.web-view;
+          web-view = pkgs.haskellPackages.web-view;
+        };
+
+        devShells = {
+          default = self.devShells.${system}.web-view;
+          web-view = pkgs.haskellPackages.shellFor (shellCommon // {
+            packages = p: [ p.web-view ];
+          });
+          example = pkgs.haskellPackages.shellFor (shellCommon // {
+            packages = _: [
+              (pkgs.haskellPackages.callCabal2nix "example" example-src {})
+            ];
+          });
+        };
+      }
+    );
+}

--- a/web-view.cabal
+++ b/web-view.cabal
@@ -18,6 +18,12 @@ license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
     embed/preflight.css
+    test/resources/basic.txt
+    test/resources/escaping.txt
+    test/resources/nested.txt
+    test/resources/nocssattrs.txt
+    test/resources/nocss.txt
+    test/resources/raw.txt
 extra-doc-files:
     README.md
     CHANGELOG.md


### PR DESCRIPTION
This is about creating a Nix flake that: 

1. Can be used by hyperbole's Nix flake to build with the same dependencies (the overlay provides this)
2. Provide an easy way to test out the example project with nix `nix develop .#example`
3. Provide CI integration for the library
4. Provide a development shell for web-view
5. Also adds the test/resources to the cabal file so Hackage gets them.

Since the golden tests do not pass, the `nix develop .#example` comamnd will fail (so does the CI). I decided to put those fixes in a separate pull request since they are code changes.

More detail:

* Add Nix flake configuration for building and development
  - Configure build inputs and overlays
  - Set up development shells for main package and example

* Add GitHub Actions workflow for CI
  - Build packages and devShells on Ubuntu and macOS
  - Test overlay application
  - Use DeterminateSystems' Nix installer and cache actions

* Update documentation
  - Add Local Development section with Nix instructions
  - Include example usage of flake overlay
  - Document dev shell and example project setup

* Fix cabal file
  - Add missing test resource files to extra-source-files