### PR TITLE
fix(nix): update to `ghc984` / `ghc967`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If you want to get a feel for atomic-css without cloning the project run `nix ru
 Import Flake
 ------------
 
-You can import this flake's overlay to add `atomic-css` to `overriddenHaskellPackages` and which provides a ghc966 and ghc982 package set that satisfy `atomic-css`'s dependencies.
+You can import this flake's overlay to add `atomic-css` to `overriddenHaskellPackages` and which provides a ghc967 and ghc984 package set that satisfy `atomic-css`'s dependencies.
 
 ```nix
 {
@@ -108,7 +108,7 @@ You can import this flake's overlay to add `atomic-css` to `overriddenHaskellPac
           inherit system;
           overlays = [ atomic-css.overlays.default ];
         };
-        haskellPackagesOverride = pkgs.overriddenHaskellPackages.ghc966.override (old: {
+        haskellPackagesOverride = pkgs.overriddenHaskellPackages.ghc967.override (old: {
           overrides = pkgs.lib.composeExtensions (old.overrides or (_: _: { })) (hfinal: hprev: {
             # your overrides here
           });
@@ -142,13 +142,13 @@ ghcid --command="cabal repl test lib:atomic-css" --run=Main.main --warnings --re
 
 ### Nix
 
-- `nix flake check` will build the library, example executable and devShell with ghc-9.8.2 and ghc-9.6.6
+- `nix flake check` will build the library, example executable and devShell with ghc-9.8.4 and ghc-9.6.7
     - This is what the CI on GitHub runs
-- `nix run` or `nix run .#ghc982-example` to start the example project with GHC 9.8.2
-    - `nix run .#ghc966-example` to start the example project with GHC 9.6.6
-- `nix develop` or `nix develop .#ghc982-shell` to get a shell with all dependencies installed for GHC 9.8.2. 
-    - `nix develop .#ghc966-shell` to get a shell with all dependencies installed for GHC 9.6.6. 
-- `nix build`, `nix build .#ghc982-atomic-css` and `nix build .#ghc966-atomic-css` builds the library with the `overriddenHaskellPackages`
+- `nix run` or `nix run .#ghc984-example` to start the example project with GHC 9.8.4
+    - `nix run .#ghc967-example` to start the example project with GHC 9.6.7
+- `nix develop` or `nix develop .#ghc984-shell` to get a shell with all dependencies installed for GHC 9.8.4. 
+    - `nix develop .#ghc967-shell` to get a shell with all dependencies installed for GHC 9.6.7. 
+- `nix build`, `nix build .#ghc984-atomic-css` and `nix build .#ghc967-atomic-css` builds the library with the `overriddenHaskellPackages`
     - If you want to import this flake, use the overlay
 - `nix flake update nixpkgs` will update the Haskell package sets and development tools
 

--- a/atomic-css.cabal
+++ b/atomic-css.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.3.
 --
 -- see: https://github.com/sol/hpack
 
@@ -17,8 +17,8 @@ license:        BSD-3-Clause
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 9.8.2
-  , GHC == 9.6.6
+    GHC == 9.8.4
+  , GHC == 9.6.7
 extra-source-files:
     embed/reset.css
 extra-doc-files:

--- a/flake.lock
+++ b/flake.lock
@@ -3,15 +3,15 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -57,11 +57,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1731533336,
-        "narHash": "sha256-oRam5PS1vcrr5UPgALW0eo1m/5/pls27Z/pabHNy2Ms=",
+        "lastModified": 1757882181,
+        "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "f7653272fd234696ae94229839a99b73c9ab7de0",
+        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736523798,
-        "narHash": "sha256-Xb8mke6UCYjge9kPR9o4P1nVrhk7QBbKv3xQ9cj7h2s=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735882644,
-        "narHash": "sha256-3FZAG+pGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -49,31 +49,17 @@
 
       overlay = final: prev: {
         overriddenHaskellPackages = {
-          ghc982 = (prev.overriddenHaskellPackages.ghc982 or prev.haskell.packages.ghc982).override (old: {
+          ghc984 = (prev.overriddenHaskellPackages.ghc984 or prev.haskell.packages.ghc984).override (old: {
             overrides = prev.lib.composeExtensions (old.overrides or (_: _: { })) (
               hfinal: hprev: {
                 "${packageName}" = hfinal.callCabal2nix packageName src { };
-                skeletest = hprev.skeletest.overrideAttrs (old: {
-                  meta = old.meta // {
-                    broken = false;
-                  };
-                });
-                Diff = hfinal.callHackage "Diff" "0.5" { };
               }
             );
           });
-          ghc966 = (prev.overriddenHaskellPackages.ghc966 or prev.haskell.packages.ghc966).override (old: {
+          ghc967 = (prev.overriddenHaskellPackages.ghc967 or prev.haskell.packages.ghc967).override (old: {
             overrides = prev.lib.composeExtensions (old.overrides or (_: _: { })) (
               hfinal: hprev: {
                 "${packageName}" = hfinal.callCabal2nix packageName src { };
-                attoparsec-aeson = hfinal.callHackage "attoparsec-aeson" "2.2.0.0" { };
-                skeletest = hprev.skeletest.overrideAttrs (old: {
-                  meta = old.meta // {
-                    broken = false;
-                  };
-                });
-                Diff = hfinal.callHackage "Diff" "0.5" { };
-                aeson = hfinal.callHackage "aeson" "2.2.2.0" { };
               }
             );
           });
@@ -102,8 +88,8 @@
         };
 
         ghcVersions = [
-          "966"
-          "982"
+          "967"
+          "984"
         ];
 
         ghcPkgs = builtins.listToAttrs (
@@ -125,7 +111,7 @@
             hlint.enable = true;
             fourmolu.enable = true;
             hpack.enable = true;
-            nixfmt-rfc-style.enable = true;
+            nixfmt.enable = true;
             flake-checker = {
               enable = true;
               args = [ "--no-telemetry" ];
@@ -171,60 +157,58 @@
             value = pkgs.runCommand "ghc${version}-check-example" {
               buildInputs = [
                 (exe version)
-              ] ++ self.devShells.${system}."ghc${version}-shell".buildInputs;
+              ]
+              ++ self.devShells.${system}."ghc${version}-shell".buildInputs;
             } "type example; CABAL_CONFIG=/dev/null cabal --dry-run repl; touch $out";
           }) ghcVersions
         );
 
-        apps =
-          {
-            default = self.apps.${system}."ghc966-${examplesName}";
-          }
-          // builtins.listToAttrs (
-            map (version: {
+        apps = {
+          default = self.apps.${system}."ghc967-${examplesName}";
+        }
+        // builtins.listToAttrs (
+          map (version: {
+            name = "ghc${version}-${examplesName}";
+            value = {
+              type = "app";
+              program = "${exe version}/bin/example";
+            };
+          }) ghcVersions
+        );
+
+        packages = {
+          default = self.packages.${system}."ghc984-${packageName}";
+        }
+        // builtins.listToAttrs (
+          builtins.concatMap (version: [
+            {
               name = "ghc${version}-${examplesName}";
-              value = {
-                type = "app";
-                program = "${exe version}/bin/example";
-              };
-            }) ghcVersions
-          );
+              value = ghcPkgs."ghc${version}".${examplesName};
+            }
+            {
+              name = "ghc${version}-${packageName}";
+              value = ghcPkgs."ghc${version}".${packageName};
+            }
+          ]) ghcVersions
+        );
 
-        packages =
-          {
-            default = self.packages.${system}."ghc982-${packageName}";
-          }
-          // builtins.listToAttrs (
-            builtins.concatMap (version: [
-              {
-                name = "ghc${version}-${examplesName}";
-                value = ghcPkgs."ghc${version}".${examplesName};
+        devShells = {
+          default = self.devShells.${system}.ghc984-shell;
+        }
+        // builtins.listToAttrs (
+          map (version: {
+            name = "ghc${version}-shell";
+            value = ghcPkgs."ghc${version}".shellFor (
+              shellCommon version
+              // {
+                packages = p: [
+                  p.${packageName}
+                  p.${examplesName}
+                ];
               }
-              {
-                name = "ghc${version}-${packageName}";
-                value = ghcPkgs."ghc${version}".${packageName};
-              }
-            ]) ghcVersions
-          );
-
-        devShells =
-          {
-            default = self.devShells.${system}.ghc982-shell;
-          }
-          // builtins.listToAttrs (
-            map (version: {
-              name = "ghc${version}-shell";
-              value = ghcPkgs."ghc${version}".shellFor (
-                shellCommon version
-                // {
-                  packages = p: [
-                    p.${packageName}
-                    p.${examplesName}
-                  ];
-                }
-              );
-            }) ghcVersions
-          );
+            );
+          }) ghcVersions
+        );
       }
     );
 }

--- a/package.yaml
+++ b/package.yaml
@@ -28,8 +28,8 @@ ghc-options:
   - -fdefer-typed-holes
 
 tested-with:
-  - GHC == 9.8.2
-  - GHC == 9.6.6
+  - GHC == 9.8.4
+  - GHC == 9.6.7
 
 default-extensions:
   - OverloadedStrings


### PR DESCRIPTION
needed to run with latest `unstable`. In other case downstreams (e.g Hyperbole) will fail by using a newer `unstable` as well. Example: https://github.com/seanhess/hyperbole/pull/205

